### PR TITLE
Fix/do not deploy to prod from branch

### DIFF
--- a/build/ado/pipeline.yml
+++ b/build/ado/pipeline.yml
@@ -179,6 +179,9 @@ stages:
               inputs:
                 targetType: inline
                 script: |
+                  # Convert to lowercase
+                  TF_VAR_is_prod_subscription=$(echo "$TF_VAR_is_prod_subscription" | tr '[:upper:]' '[:lower:]')
+
                   eirctl infra:vars
               env:
                 TF_VAR_create_fabric_capacity: true

--- a/build/ado/pipeline.yml
+++ b/build/ado/pipeline.yml
@@ -8,7 +8,7 @@ parameters:
 
   - name: deploy_all_environments
     type: boolean
-    default: true
+    default: false
     displayName: Deploy All Environments
 
   - name: destroy_infrastructure

--- a/build/ado/pipeline.yml
+++ b/build/ado/pipeline.yml
@@ -185,7 +185,7 @@ stages:
                 TF_VAR_permissions: $(fabric_permissions)
                 TF_VAR_ado_org_service_url: $(ado_org_service_url)
                 TF_VAR_ado_project_name: $(ado_project_name)
-                TF_VAR_is_prod_subscription: lower(${{ env.is_prod_subscription }})
+                TF_VAR_is_prod_subscription: lower("${{ env.is_prod_subscription }}")
                 TF_VAR_environments: ${{ env.definition }}
 
             # If the debug option has been enabled, upload the vars file that has been created

--- a/build/ado/pipeline.yml
+++ b/build/ado/pipeline.yml
@@ -31,14 +31,14 @@ parameters:
         condition: succeeded()
         credentials_group: azure_sp_creds
         definition: test:false
-        is_prod_subscription: "false"
+        is_prod_subscription: 'false'
       - name: uat
         type: nonprod
         dependsOn: prelim
         condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables.deploy_all_environments, true)))
         credentials_group: azure_sp_creds
         definition: uat:false
-        is_prod_subscription: "false"
+        is_prod_subscription: 'false'
       - name: prod
         type: prod
         dependsOn:
@@ -47,7 +47,7 @@ parameters:
         condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables.deploy_all_environments, true)))
         credentials_group: azure_sp_creds
         definition: prod:true
-        is_prod_subscription: "true"
+        is_prod_subscription: 'true'
 
   - name: debug
     displayName: Enable Debugging
@@ -151,8 +151,6 @@ stages:
           value: deploy/terraform
         - name: ENV_NAME
           value: ${{ env.name }}
-        - name: is_prod_subscription
-          value: lower("${{ env.is_prod_subscription }}")
 
       jobs:
         - job: deploy_infra
@@ -187,7 +185,7 @@ stages:
                 TF_VAR_permissions: $(fabric_permissions)
                 TF_VAR_ado_org_service_url: $(ado_org_service_url)
                 TF_VAR_ado_project_name: $(ado_project_name)
-                TF_VAR_is_prod_subscription: $(is_prod_subscription)
+                TF_VAR_is_prod_subscription: ${{ env.is_prod_subscription }}
                 TF_VAR_environments: ${{ env.definition }}
 
             # If the debug option has been enabled, upload the vars file that has been created

--- a/build/ado/pipeline.yml
+++ b/build/ado/pipeline.yml
@@ -185,7 +185,7 @@ stages:
                 TF_VAR_permissions: $(fabric_permissions)
                 TF_VAR_ado_org_service_url: $(ado_org_service_url)
                 TF_VAR_ado_project_name: $(ado_project_name)
-                TF_VAR_is_prod_subscription: ${{ env.is_prod_subscription }}
+                TF_VAR_is_prod_subscription: lower(${{ env.is_prod_subscription }})
                 TF_VAR_environments: ${{ env.definition }}
 
             # If the debug option has been enabled, upload the vars file that has been created

--- a/build/ado/pipeline.yml
+++ b/build/ado/pipeline.yml
@@ -151,6 +151,8 @@ stages:
           value: deploy/terraform
         - name: ENV_NAME
           value: ${{ env.name }}
+        - name: is_prod_subscription
+          value: lower("${{ env.is_prod_subscription }}")
 
       jobs:
         - job: deploy_infra
@@ -185,7 +187,7 @@ stages:
                 TF_VAR_permissions: $(fabric_permissions)
                 TF_VAR_ado_org_service_url: $(ado_org_service_url)
                 TF_VAR_ado_project_name: $(ado_project_name)
-                TF_VAR_is_prod_subscription: lower("${{ env.is_prod_subscription }}")
+                TF_VAR_is_prod_subscription: $(is_prod_subscription)
                 TF_VAR_environments: ${{ env.definition }}
 
             # If the debug option has been enabled, upload the vars file that has been created


### PR DESCRIPTION
#### 📲 What

Update stages and modified parameter so that only the test environment is deployed to when a PR is raised

#### 🤔 Why

We need to test any infrastructure updates that are created, but this should only be done in the TEST environment and not propagated to UAT and PROD

#### 🛠 How

The `condition` on the stage checks that it is being run from the `main` branch and will not deploy to UAT and PROD if not.

Additionally the parameter that allows the deployment to be forced to all enviroiinments is now false by default.

#### 👀 Evidence

The pipeline diagram shows the build only running to DEV on a barnch (and therefore a PR)

![image](https://github.com/user-attachments/assets/3495ee13-c6d7-406e-a5fb-763d0968d762)

