### PR TITLE
pre-commit updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,26 +16,22 @@ repos:
     hooks:
       - id: yamllint
         args: ["-c=yamllint.conf"]
-        exclude: de_workloads/ingest/ingest_azure_sql_example/de-ingest-ado-pipeline.yml
   - repo: https://github.com/pycqa/flake8
-    rev: "7.2.0"
+    rev: "7.3.0"
     hooks:
       - id: flake8
-        exclude: |
-          (?x)^(
-              .venv|
-              .git
-          )$
-        args:
-          - "--max-line-length=120"
+        files: ^fabric_content/
+        args: ["--config=fabric_content/.flake8"]
   - repo: https://github.com/psf/black
     rev: 25.1.0
     hooks:
       - id: black
-        language_version: python3.10
+        files: ^fabric_content/
+        args: ["--config=fabric_content/pyproject.toml"]
   - repo: https://github.com/pycqa/pydocstyle
     rev: 6.3.0
     hooks:
       - id: pydocstyle
+        files: ^fabric_content/
         args: ["--config=fabric_content/pyproject.toml"]
         additional_dependencies: ["tomli"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+## -------------------------------
+## Pre-commit Hooks
+## -------------------------------
+
+.PHONY: pre-commit-install pre-commit-run pre-commit-all pre-commit-update
+
+pre-commit-install:
+	@echo "Installing pre-commit hooks..."
+	pre-commit install
+
+pre-commit-run:
+	@echo "Running pre-commit on staged files..."
+	pre-commit run
+
+pre-commit-all:
+	@echo "Running all pre-commit hooks on all files..."
+	pre-commit run --all-files
+
+pre-commit-update:
+	@echo "Updating pre-commit hook versions..."
+	pre-commit autoupdate

--- a/README.md
+++ b/README.md
@@ -6,42 +6,55 @@ This repo holds the infrastructure and code required for deploying Azure Fabric 
 
 This project uses [pre-commit](https://pre-commit.com/) to automate code quality checks and formatting.
 
-### Pre-commit hook installation
+The checks for the project are defined in [.pre-commit-config.yaml](/.pre-commit-config.yaml).
+
+[Make commands](./Makefile) have been provided to simplify setup and usage.
+
+### Pre-commit setup
 
 To ensure pre-commit checks run automatically on every `git commit`, you must install the git hooks after cloning the repository:
 
+1. Install the `pre-commit` CLI (if not already installed):
+
+   ```sh
+   pip install --user pre-commit
+   ```
+
+2. Install the Git hooks (from the root of the repo):
+
+   ```sh
+   make pre-commit-install
+   ```
+
+You only need to do this once. After that, pre-commit will run automatically on every commit.
+
+### Run pre-commit checks manually
+
+You can run pre-commit hooks manually at any time:
+
+- **Run hooks only on staged files**:
+
+  ```sh
+  make pre-commit-run
+  ```
+
+- **Run all hooks on all files** (useful after updating hooks or dependencies):
+
+  ```sh
+  make pre-commit-all
+  ```
+
+### Updating Hook Versions
+
+To update pre-commit hooks to their latest versions (defined in `.pre-commit-config.yaml`):
+
 ```sh
-poetry run pre-commit install
+make pre-commit-update
 ```
 
-You only need to do this once per clone. After that, pre-commit will run automatically on every commit.
-
-### How to run pre-commit checks
-
-- **Run all checks on all files:**
-  ```sh
-  poetry run pre-commit run --all-files
-  ```
-- **Run checks only on staged files (default on commit):**
-  ```sh
-  poetry run pre-commit run
-  ```
-- **Run a specific hook:**
-  ```sh
-  poetry run pre-commit run <hook-id> --all-files
-  ```
-  Replace `<hook-id>` with the name of the hook (e.g., `black`, `flake8`).
-
-### Common parameters
-- `--all-files` : Run the hook(s) on all files, not just changed ones.
-- `-v` or `--verbose` : Show detailed output.
-- `--show-diff-on-failure` : Show a diff when a hook fails and can fix the file.
-- `--hook-stage <stage>` : Run hooks for a specific git stage (e.g., `commit`, `push`).
+Then commit any changes made to the config file.
 
 ### Notes
+
 - Hooks like `black` and `end-of-file-fixer` will auto-fix issues.
 - Linters like `flake8` and `yamllint` will only report issues for you to fix manually.
-- You can update hooks to their latest versions with:
-  ```sh
-  poetry run pre-commit autoupdate
-  ```

--- a/fabric_content/.flake8
+++ b/fabric_content/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max_line_length = 120
+exclude = .venv,.git

--- a/fabric_content/pyproject.toml
+++ b/fabric_content/pyproject.toml
@@ -45,10 +45,6 @@ exclude = '''
 )/
 '''
 
-[tool.flake8]
-max_line_length = 120
-exclude = ".venv,.git"
-
 [tool.pydocstyle]
 convention = "google"
 add_ignore = "D100,D101,D104"


### PR DESCRIPTION
#### 📲 What

Updates to pre-commit setup instructions and configurations.

#### 🤔 Why

So we're enable to run pre-commit over the whole project (not just within fabric_content when using poetry).

#### 🛠 How

- README in project root no longer specifies poetry commands , has steps that all developers can follow for using pre-commit
- Have added a Makefile to simplify commands
- Updates to config file, so python-related checks only run within `fabric_content` directory

#### 👀 Evidence

Am able to run precommit over the project, without needing a poetry shell.
Note - several checks currently fail - these will be rectified in a future PR.

#### 🕵️ How to test

Follow steps in README to setup and run pre-commit.

#### ✅ Acceptance criteria Checklist

- [x] Code peer reviewed?
- [x] Documentation has been updated to reflect the changes?
- [x] Passing all automated tests, including a successful deployment?
- [x] Passing any exploratory testing?
- [x] Rebased/merged with latest changes from development and re-tested?
- [x] Meeting the Coding Standards?
