### PR TITLE
fix: update vulnerable Azure SDK dependencies and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,81 @@
+version: 2
+updates:
+  # Python dependencies managed by Poetry
+  - package-ecosystem: pip
+    directory: "/fabric_content"
+    schedule:
+      interval: weekly
+      day: monday
+      timezone: Europe/London
+    open-pull-requests-limit: 50
+    rebase-strategy: disabled
+    groups:
+      low-risk:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Main Terraform infrastructure
+  - package-ecosystem: terraform
+    directory: "/deploy/terraform/infra"
+    schedule:
+      interval: weekly
+      day: monday
+      timezone: Europe/London
+    open-pull-requests-limit: 50
+    rebase-strategy: disabled
+    groups:
+      low-risk:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Example copy pipeline Terraform
+  - package-ecosystem: terraform
+    directory: "/fabric_content/data_engineering/example_copy_pipeline/ado"
+    schedule:
+      interval: weekly
+      day: monday
+      timezone: Europe/London
+    open-pull-requests-limit: 50
+    rebase-strategy: disabled
+    groups:
+      low-risk:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Example Spark pipeline Terraform
+  - package-ecosystem: terraform
+    directory: "/fabric_content/data_engineering/example_spark_pipeline/deploy/terraform/workload"
+    schedule:
+      interval: weekly
+      day: monday
+      timezone: Europe/London
+    open-pull-requests-limit: 50
+    rebase-strategy: disabled
+    groups:
+      low-risk:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions in pre-commit hooks
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      timezone: Europe/London
+    open-pull-requests-limit: 50
+    rebase-strategy: disabled
+    groups:
+      low-risk:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"

--- a/fabric_content/poetry.lock
+++ b/fabric_content/poetry.lock
@@ -41,41 +41,41 @@ files = [
 
 [[package]]
 name = "azure-core"
-version = "1.30.2"
+version = "1.38.0"
 description = "Microsoft Azure Core Library for Python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "azure-core-1.30.2.tar.gz", hash = "sha256:a14dc210efcd608821aa472d9fb8e8d035d29b68993819147bc290a8ac224472"},
-    {file = "azure_core-1.30.2-py3-none-any.whl", hash = "sha256:cf019c1ca832e96274ae85abd3d9f752397194d9fea3b41487290562ac8abe4a"},
+    {file = "azure_core-1.38.0-py3-none-any.whl", hash = "sha256:ab0c9b2cd71fecb1842d52c965c95285d3cfb38902f6766e4a471f1cd8905335"},
+    {file = "azure_core-1.38.0.tar.gz", hash = "sha256:8194d2682245a3e4e3151a667c686464c3786fed7918b394d035bdcd61bb5993"},
 ]
 
 [package.dependencies]
 requests = ">=2.21.0"
-six = ">=1.11.0"
 typing-extensions = ">=4.6.0"
 
 [package.extras]
 aio = ["aiohttp (>=3.0)"]
+tracing = ["opentelemetry-api (>=1.26,<2.0)"]
 
 [[package]]
 name = "azure-identity"
-version = "1.15.0"
+version = "1.16.1"
 description = "Microsoft Azure Identity Library for Python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "azure-identity-1.15.0.tar.gz", hash = "sha256:4c28fc246b7f9265610eb5261d65931183d019a23d4b0e99357facb2e6c227c8"},
-    {file = "azure_identity-1.15.0-py3-none-any.whl", hash = "sha256:a14b1f01c7036f11f148f22cd8c16e05035293d714458d6b44ddf534d93eb912"},
+    {file = "azure-identity-1.16.1.tar.gz", hash = "sha256:6d93f04468f240d59246d8afde3091494a5040d4f141cad0f49fc0c399d0d91e"},
+    {file = "azure_identity-1.16.1-py3-none-any.whl", hash = "sha256:8fb07c25642cd4ac422559a8b50d3e77f73dcc2bbfaba419d06d6c9d7cff6726"},
 ]
 
 [package.dependencies]
-azure-core = ">=1.23.0,<2.0.0"
+azure-core = ">=1.23.0"
 cryptography = ">=2.5"
-msal = ">=1.24.0,<2.0.0"
-msal-extensions = ">=0.3.0,<2.0.0"
+msal = ">=1.24.0"
+msal-extensions = ">=0.3.0"
 
 [[package]]
 name = "azure-mgmt-core"
@@ -1890,19 +1890,19 @@ files = [
 
 [[package]]
 name = "stacks-data"
-version = "2.1.2"
+version = "2.1.4"
 description = "A suite of utilities to support data engineering workloads within an Ensono Stacks data platform."
 optional = false
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
 files = [
-    {file = "stacks_data-2.1.2-py3-none-any.whl", hash = "sha256:bc87cef8b2c7620ef191632a84f7a87ad02e184e54f5ba258202da9e9dedd947"},
-    {file = "stacks_data-2.1.2.tar.gz", hash = "sha256:f0f3cdab2adf7cd3020e32a6ba9108a2195b16bd6523dc35968d49d331ae2351"},
+    {file = "stacks_data-2.1.4-py3-none-any.whl", hash = "sha256:ab20b72c3fdd402f7dec7556342951b2f67d385e021f530a2d359901775a2f6c"},
+    {file = "stacks_data-2.1.4.tar.gz", hash = "sha256:8dc2ae71233cd4f57130e494ea507e55abd77f460c11981a1be9bb5ad6b8706d"},
 ]
 
 [package.dependencies]
-azure-core = "1.30.2"
-azure-identity = "1.15.0"
+azure-core = "1.38.0"
+azure-identity = "1.16.1"
 azure-mgmt-datafactory = ">=3.1.0,<4.0.0"
 azure-storage-file-datalake = ">=12.16.0,<13.0.0"
 colorlog = ">=6.8.2,<7.0.0"
@@ -2003,4 +2003,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "15f328d527c5a4380e6cfef77b2bbbc7d4f530ee08d0f9277bd2f88ea3e956b0"
+content-hash = "2050c00e7f140c33083377d92f4f1abbc2de2ab355a4bbafa9f4babaf65da24b"

--- a/fabric_content/pyproject.toml
+++ b/fabric_content/pyproject.toml
@@ -8,6 +8,8 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.11,<3.13"
 dependencies = [
+    "azure-core (>=1.38.0,<2.0.0)",
+    "azure-identity (>=1.16.1,<2.0.0)",
     "azure-storage-file-datalake (>=12.20.0,<13.0.0)",
     "black (>=25.1.0,<26.0.0)",
     "chispa (>=0.11.1,<0.12.0)",


### PR DESCRIPTION
## Description

This PR addresses two security vulnerabilities in Azure SDK dependencies:

- **GHSA-jm66-cg57-jjv5** (CVE-2026-21226, High): Azure Core deserialization vulnerability
- **GHSA-m5vv-6r4h-3vj9** (CVE-2024-35255, Moderate): Azure Identity privilege escalation

## Changes

- ✅ Updated `azure-core` from 1.30.2 to 1.38.0
- ✅ Updated `azure-identity` from 1.15.0 to 1.16.1
- ✅ Regenerated `poetry.lock` with updated dependencies
- ✅ Added `.github/dependabot.yml` for automated weekly dependency scanning

## Dependabot Configuration

The new Dependabot configuration monitors:
- Python dependencies (pip/poetry) in `fabric_content/`
- Terraform providers in 3 infrastructure directories
- GitHub Actions in pre-commit hooks

Updates are scheduled weekly (Mondays) with minor/patch versions automatically grouped.

## Verification

- [x] Poetry configuration valid (`poetry check`)
- [x] Pre-commit hooks passed
- [x] No breaking changes expected from Azure SDK patch updates